### PR TITLE
Use native printf instead of OCaml's to avoid crash on Windows

### DIFF
--- a/src/Timber.re
+++ b/src/Timber.re
@@ -167,6 +167,18 @@ let consoleReporter = {
     Fmt.pf(ppf, "%a", style, level);
   };
 
+  let buffer = Buffer.create(0);
+  let formatter =
+    Format.make_formatter(
+      Buffer.add_substring(buffer),
+      () => {
+        // We use `Console.log` instead of `print_endline` / default formatter to work around:
+        // https://github.com/ocaml/ocaml/issues/9252
+        Console.err(Buffer.contents(buffer));
+        Buffer.clear(buffer);
+      },
+    );
+
   Logs.{
     report: (_src, level, ~over, k, msgf) => {
       let k = _ => {
@@ -182,7 +194,7 @@ let consoleReporter = {
 
         Format.kfprintf(
           k,
-          Format.err_formatter,
+          formatter,
           "%a %a %a : @[" ^^ fmt ^^ "@]@.",
           pp_level_styled,
           level,

--- a/src/dune
+++ b/src/dune
@@ -7,4 +7,5 @@
         logs
         logs.fmt
         re
+        console.lib
     ))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
     (name Timber)
     (public_name timber)
+    (c_names  nativeChannels)
     (libraries 
         fmt
         fmt.tty

--- a/src/nativeChannels.c
+++ b/src/nativeChannels.c
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ // This file has been adapted from reason-native/console:
+ // https://github.com/facebookexperimental/reason-native/blob/master/src/console/nativeChannels.c
+
+#define CAML_NAME_SPACE
+
+#include <stdio.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+
+CAMLprim value native_error(value str)
+{
+  CAMLparam1(str);
+  fprintf(stderr, "%s", String_val(str));
+  CAMLreturn(Val_unit);
+}


### PR DESCRIPTION
This borrows parts of reason-native/console so we can use the native printf function directly, and sets the style renderer on our custom formatter so we get those sweet colors as well.

cc @bryphe