### PR TITLE
Add minute and hour formatting

### DIFF
--- a/example/Example.re
+++ b/example/Example.re
@@ -32,3 +32,29 @@ Timber.App.setLogFile("test.log");
   Log.fn("Unix.sleepf", Unix.sleepf, 0.25);
   Log.fn("Unix.getppid", ~pp=string_of_int, Unix.getppid, ());
 };
+
+{
+  module Log = (val Timber.Log.withNamespace("Timber.Time"));
+  let secondsAgo = f => Timber.Debug.setLastLogTime(Unix.gettimeofday() -. f);
+
+  secondsAgo(9.90);
+  Log.info("Large milliseconds");
+
+  secondsAgo(10.01);
+  Log.info("Small seconds");
+
+  secondsAgo(599.90);
+  Log.info("Large seconds");
+
+  secondsAgo(600.01);
+  Log.info("Small minutes");
+
+  secondsAgo(35999.90);
+  Log.info("Large minutes");
+
+  secondsAgo(36000.01);
+  Log.info("Small hours");
+
+  secondsAgo(99999.01);
+  Log.info("Large hours");
+};

--- a/src/DeltaTime.re
+++ b/src/DeltaTime.re
@@ -7,8 +7,16 @@ let get = () => {
   delta;
 };
 
+let set = x => last := x;
+
 let pp = (ppf, dt) =>
-  if (dt > 10.) {
+  if (dt > 36000.) {
+    Fmt.pf(ppf, "%+6.1fh", dt /. 3600.);
+  } else if (dt > 600.) {
+    Fmt.pf(ppf, "%+6.1fm", dt /. 60.);
+  } else if (dt > 100.) {
+    Fmt.pf(ppf, "%+6.1fs", dt);
+  } else if (dt > 10.) {
     Fmt.pf(ppf, "%+6.2fs", dt);
   } else {
     Fmt.pf(ppf, "%+5.0fms", dt *. 1000.);

--- a/src/DeltaTime.rei
+++ b/src/DeltaTime.rei
@@ -1,3 +1,4 @@
 let tag: Logs.Tag.def(float);
 let get: unit => float;
+let set: float => unit;
 let pp: Fmt.t(float);

--- a/src/Timber.re
+++ b/src/Timber.re
@@ -100,6 +100,10 @@ module App = {
   let setNamespaceFilter = Namespace.setFilter;
 };
 
+module Debug = {
+  let setLastLogTime = DeltaTime.set;
+};
+
 // init
 let () =
   if (Sys.win32) {

--- a/src/Timber.rei
+++ b/src/Timber.rei
@@ -26,7 +26,7 @@ module Level: {
 };
 
 module Log: {
-  let withNamespace: string => (module Logger);
+  let withNamespace: (string) => (module Logger);
   let perf: (string, unit => 'a) => 'a;
 };
 
@@ -55,4 +55,12 @@ module App: {
    *   setNamespaceFilter("Oni2.*, -Revery*")
    */
   let setNamespaceFilter: string => unit;
+};
+
+module Debug: {
+  /**
+   * Sets the internally stored last time of a log. This should not be used
+   * except for testing.
+   */
+  let setLastLogTime: float => unit;
 };


### PR DESCRIPTION
Fixes #4 

This should now keep the length of the time string consistent up to 999.9 hours.

- Whenever seconds are above 100 precision is reduced to 1 decimal
- After 10 minutes pass it switches to minutes
- After 10 hours pass it switches to hours

I've also exposed a method to set the last time so I could test this. I can remove or rename that function/module

<img width="665" alt="Screen Shot 2020-03-01 at 4 55 40 PM" src="https://user-images.githubusercontent.com/1830497/75637920-38152a80-5bde-11ea-99ac-1c502efe3cc0.png">
